### PR TITLE
Fix rescale fail with floats

### DIFF
--- a/src/caked/dataloader.py
+++ b/src/caked/dataloader.py
@@ -166,7 +166,7 @@ class DiskDataLoader(AbstractDataLoader):
         for i in transforms:
             if i.startswith("rescale"):
                 transforms.remove(i)
-                rescale = int(i.split("=")[-1])
+                rescale = int(float(i.split("=")[-1]))
 
         if len(transforms) > 0:
             msg = f"The following transformations are not supported: {transforms}"


### PR DESCRIPTION
Rescale transform first performs numerical conversion, and then drops the floating point to prevent failures when floats sneak in during default processing.

Fixes #29 